### PR TITLE
fix: queue pi-nvim prompts as follow-ups

### DIFF
--- a/extension.ts
+++ b/extension.ts
@@ -116,7 +116,7 @@ export default function (pi: ExtensionAPI) {
         // Exit kitty's scrollback viewer by switching to private screen mode
         // and back. This snaps to the bottom without clearing scrollback history.
         process.stdout.write("\x1b[?1049h\x1b[?1049l");
-        pi.sendUserMessage(msg.message);
+        pi.sendUserMessage(msg.message, { deliverAs: "followUp" });
         respond(conn, { ok: true });
         return;
       }


### PR DESCRIPTION
## Summary

Send pi messages as follow-up messages while pi is streaming.
Reference: https://github.com/earendil-works/pi/blob/26f1e00/packages/coding-agent/docs/extensions.md#L1291-L1317

Fixes #6.
