### PR TITLE
fix: support Windows via named pipes

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ The repo contains two components:
 
 Discovery is automatic: the extension writes socket info to `/tmp/pi-nvim-sockets/`, and the Neovim plugin scans that directory, preferring sessions matching your cwd.
 
+On Windows, unix sockets don't exist, so the extension binds a named pipe (`\\.\pipe\pi-nvim-*`) and writes the manifests into `%TEMP%/pi-nvim-sockets/` instead — the plugin reads the actual connect address from the manifest's `socket` field. Unix behavior is unchanged.
+
 ## Install
 
 ### Pi side

--- a/index.ts
+++ b/index.ts
@@ -1,16 +1,17 @@
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import * as net from "node:net";
 import * as fs from "node:fs";
+import * as os from "node:os";
 import * as path from "node:path";
 import * as crypto from "node:crypto";
 
 /**
- * pi-nvim: Exposes a unix socket so external tools (like a neovim plugin)
+ * pi-nvim: Exposes a socket so external tools (like a neovim plugin)
  * can send prompts/context into a running interactive pi session.
  *
  * Repo: https://github.com/carderne/pi-nvim
  *
- * Protocol: newline-delimited JSON over a unix socket.
+ * Protocol: newline-delimited JSON over a socket.
  *
  * Commands:
  *   { "type": "prompt", "message": "..." }
@@ -22,28 +23,42 @@ import * as crypto from "node:crypto";
  *   { "ok": true, "type": "pong" }
  *   { "ok": false, "error": "..." }
  *
- * Socket path: /tmp/pi-nvim-<hash-of-cwd>.sock
- * A symlink at /tmp/pi-nvim-latest.sock always points to the most recently
- * started session, so neovim can just connect there if there's only one.
- *
- * The socket path for a given cwd is also written to /tmp/pi-nvim-sockets/<hash>
- * as a plain text file containing the cwd, so neovim can list all running sessions.
+ * Unix: unix socket at /tmp/pi-nvim-sockets/<hash>-<pid>.sock, a symlink at
+ * /tmp/pi-nvim-latest.sock, and a .info manifest next to each socket.
+ * Windows: unix sockets don't exist, so bind a named pipe
+ * \\.\pipe\pi-nvim-<hash>-<pid> instead. The manifest (.info) lives in
+ * %TEMP%/pi-nvim-sockets together with a marker <hash>-<pid>.sock file so the
+ * nvim side can stat for liveness; the JSON carries the connect address in
+ * "socket". The nvim plugin computes the same dir from TEMP (see sockets_dir()).
  */
 
 function cwdHash(cwd: string): string {
   return crypto.createHash("md5").update(cwd).digest("hex").slice(0, 12);
 }
 
-function getSocketPath(cwd: string): string {
-  return path.join(SOCKETS_DIR, `${cwdHash(cwd)}-${process.pid}.sock`);
+const IS_WIN = process.platform === "win32";
+const SOCKETS_DIR = IS_WIN ? path.join(os.tmpdir(), "pi-nvim-sockets") : "/tmp/pi-nvim-sockets";
+// Windows has no symlinks here; discovery relies solely on the .info manifests.
+const LATEST_LINK = IS_WIN ? null : "/tmp/pi-nvim-latest.sock";
+
+function socketBase(cwd: string): string {
+  return `${cwdHash(cwd)}-${process.pid}`;
 }
 
-const SOCKETS_DIR = "/tmp/pi-nvim-sockets";
-const LATEST_LINK = "/tmp/pi-nvim-latest.sock";
+/** Path of the socket file (unix) or the liveness marker file (Windows). */
+function socketFilePath(cwd: string): string {
+  return path.join(SOCKETS_DIR, `${socketBase(cwd)}.sock`);
+}
+
+/** Actual listen address: a unix socket path or a Windows named pipe. */
+function getSocketPath(cwd: string): string {
+  return IS_WIN ? `\\\\.\\pipe\\pi-nvim-${socketBase(cwd)}` : socketFilePath(cwd);
+}
 
 export default function (pi: ExtensionAPI) {
   let server: net.Server | null = null;
   let socketPath: string | null = null;
+  let markerFile: string | null = null;
 
   pi.on("session_start", async (_event, ctx) => {
     const cwd = ctx.cwd;
@@ -53,10 +68,14 @@ export default function (pi: ExtensionAPI) {
     } catch {}
 
     socketPath = getSocketPath(cwd);
+    markerFile = socketFilePath(cwd);
 
-    // Clean up stale socket
+    // Clean up stale socket/marker
     try {
       fs.unlinkSync(socketPath);
+    } catch {}
+    try {
+      fs.unlinkSync(markerFile);
     } catch {}
 
     server = net.createServer((conn) => {
@@ -75,21 +94,26 @@ export default function (pi: ExtensionAPI) {
     });
 
     server.listen(socketPath, () => {
-      // Update latest symlink
-      try {
-        fs.unlinkSync(LATEST_LINK);
-      } catch {}
-      try {
-        fs.symlinkSync(socketPath!, LATEST_LINK);
-      } catch {}
+      // Update latest symlink (unix only)
+      if (LATEST_LINK) {
+        try {
+          fs.unlinkSync(LATEST_LINK);
+        } catch {}
+        try {
+          fs.symlinkSync(socketPath!, LATEST_LINK);
+        } catch {}
+      }
 
       // Register in sockets directory for discovery
       try {
         fs.mkdirSync(SOCKETS_DIR, { recursive: true });
-        // Write a manifest file alongside the socket for discovery
+        // Windows: named pipes aren't visible in the filesystem, so leave a
+        // marker file the nvim side can stat for liveness.
+        if (IS_WIN) fs.writeFileSync(markerFile!, "");
         fs.writeFileSync(
-          socketPath + ".info",
+          markerFile! + ".info",
           JSON.stringify({
+            socket: socketPath,
             cwd,
             pid: process.pid,
             startedAt: new Date().toISOString(),
@@ -138,16 +162,22 @@ export default function (pi: ExtensionAPI) {
       server.close();
       server = null;
     }
+    if (!socketPath) return;
     try {
-      fs.unlinkSync(socketPath!);
+      fs.unlinkSync(socketPath);
     } catch {}
     try {
-      // Clean up latest symlink if it points to us
-      const target = fs.readlinkSync(LATEST_LINK);
-      if (target === socketPath) fs.unlinkSync(LATEST_LINK);
+      if (markerFile) fs.unlinkSync(markerFile);
     } catch {}
     try {
-      fs.unlinkSync(socketPath + ".info");
+      // Clean up latest symlink if it points to us (unix only)
+      if (LATEST_LINK) {
+        const target = fs.readlinkSync(LATEST_LINK);
+        if (target === socketPath) fs.unlinkSync(LATEST_LINK);
+      }
+    } catch {}
+    try {
+      if (markerFile) fs.unlinkSync(markerFile + ".info");
     } catch {}
   }
 

--- a/lua/pi-nvim/init.lua
+++ b/lua/pi-nvim/init.lua
@@ -1,5 +1,15 @@
 local M = {}
 
+--- Directory holding the .info manifests / marker files. Must match the
+--- pi extension's SOCKETS_DIR: /tmp on unix, %TEMP% on Windows.
+local function sockets_dir()
+  if vim.fn.has("win32") == 1 then
+    local tmp = vim.env.TEMP or vim.env.TMP
+    return tmp and (tmp:gsub("\\", "/") .. "/pi-nvim-sockets") or nil
+  end
+  return "/tmp/pi-nvim-sockets"
+end
+
 --- @class pi_nvim.Config
 --- @field socket_path string|nil  Override socket path (default: auto-discover)
 --- @field set_default_keymaps boolean|nil  Whether to create the default <leader>p mappings (default: true)
@@ -73,51 +83,49 @@ function M.get_socket_path()
     return M.config.socket_path
   end
 
-  local sockets_dir = "/tmp/pi-nvim-sockets"
+  local sd = sockets_dir()
+  if not sd then return nil end
   local cwd = vim.uv.cwd()
 
   -- Scan the sockets directory for .info files
-  local ok, files = pcall(vim.fn.glob, sockets_dir .. "/*.info", false, true)
+  local ok, files = pcall(vim.fn.glob, sd .. "/*.info", false, true)
   if ok and files then
-    -- First pass: exact cwd match, prefer newest socket
-    local best_sock = nil
-    local best_mtime = 0
+    -- Collect live sessions. The .sock file is a real unix socket on unix and
+    -- a liveness marker on Windows; the connect address always comes from the
+    -- manifest's "socket" field (falls back to the file-derived path).
+    local best_sock, best_mtime = nil, 0
+    local any_sock, any_mtime = nil, 0
     for _, info_path in ipairs(files) do
       local content_ok, content = pcall(vim.fn.readfile, info_path)
       if content_ok and content and content[1] then
         local parsed_ok, info = pcall(vim.json.decode, content[1])
         if parsed_ok and info then
-          local sock = info_path:sub(1, -6) -- strip ".info"
-          local stat = vim.uv.fs_stat(sock)
-          if info.cwd == cwd and stat then
-            if stat.mtime.sec > best_mtime then
+          local sock_file = info_path:sub(1, -6) -- strip ".info"
+          local stat = vim.uv.fs_stat(sock_file)
+          local addr = info.socket or sock_file
+          if stat then
+            if stat.mtime.sec > any_mtime then
+              any_mtime = stat.mtime.sec
+              any_sock = addr
+            end
+            if info.cwd == cwd and stat.mtime.sec > best_mtime then
               best_mtime = stat.mtime.sec
-              best_sock = sock
+              best_sock = addr
             end
           end
         end
       end
     end
     if best_sock then return best_sock end
-
-    -- Second pass: any live session (newest)
-    for _, info_path in ipairs(files) do
-      local sock = info_path:sub(1, -6)
-      local stat = vim.uv.fs_stat(sock)
-      if stat then
-        if stat.mtime.sec > best_mtime then
-          best_mtime = stat.mtime.sec
-          best_sock = sock
-        end
-      end
-    end
-    if best_sock then return best_sock end
+    if any_sock then return any_sock end
   end
 
-  -- Fall back to latest symlink
-  local latest = "/tmp/pi-nvim-latest.sock"
-  if vim.uv.fs_stat(latest) then
-    return latest
+  -- Fall back to latest symlink (unix only; Windows has none)
+  if vim.fn.has("win32") == 0 then
+    local latest = "/tmp/pi-nvim-latest.sock"
+    if vim.uv.fs_stat(latest) then
+      return latest
+    end
   end
 
   return nil
@@ -332,8 +340,12 @@ end
 
 --- List all running pi sessions.
 function M.list_sessions()
-  local sockets_dir = "/tmp/pi-nvim-sockets"
-  local ok, files = pcall(vim.fn.glob, sockets_dir .. "/*.info", false, true)
+  local sd = sockets_dir()
+  if not sd then
+    vim.notify("No pi sessions found", vim.log.levels.INFO)
+    return
+  end
+  local ok, files = pcall(vim.fn.glob, sd .. "/*.info", false, true)
   if not ok or not files or #files == 0 then
     vim.notify("No pi sessions found", vim.log.levels.INFO)
     return
@@ -345,8 +357,8 @@ function M.list_sessions()
     if content_ok and content and content[1] then
       local parsed_ok, info = pcall(vim.json.decode, content[1])
       if parsed_ok and info then
-        local sock = info_path:sub(1, -6)
-        local alive = vim.uv.fs_stat(sock) ~= nil
+        local sock_file = info_path:sub(1, -6)
+        local alive = vim.uv.fs_stat(sock_file) ~= nil
         if alive then
           -- Format start time as relative or short time
           local started = ""
@@ -365,7 +377,7 @@ function M.list_sessions()
             cwd = info.cwd or "?",
             pid = info.pid or "?",
             started = started,
-            socket = sock,
+            socket = info.socket or sock_file,
           })
         end
       end


### PR DESCRIPTION
## Problem

On Windows, the extension fails at startup with:

```
Error: pi-nvim error: listen EACCES: permission denied \tmp\pi-nvim-sockets\b1b1758f3129-42152.sock
```

Node cannot bind a unix socket there (Windows has no `AF_UNIX` sockets for `net.Server.listen` in this mode), and the hardcoded `/tmp` directory can't be created, so the whole bridge breaks.

## Changes

- **Both components of the repo were updated** (extension + Neovim plugin), since the socket location is shared between them.
- `extension.ts`: on win32, bind a named pipe (`\.\pipe\pi-nvim-<hash>-<pid>`) instead of a unix socket, and write the `.info` manifests into `%TEMP%/pi-nvim-sockets/`. The manifest JSON now carries the actual connect address in a new `socket` field, plus a marker `.sock` file so the plugin can still stat for liveness. Unix paths are byte-for-byte unchanged.
- `lua/pi-nvim/init.lua`: resolve the manifests dir from `%TEMP%` on win32 (`/tmp` on unix), connect using `info.socket` (falls back to the file-derived path for old manifests, so existing setups keep working), and skip the `latest.sock` symlink fallback on Windows.
- `README.md`: document the Windows behavior.

## Verification

End-to-end on Windows: a test script binds the named pipe and drops exactly the same marker + manifest files the patched extension writes, then a headless Neovim with this plugin auto-discovers the session and completes a ping/pong round-trip:

```
PING_RESULT=OK pong
```

## Notes

- Named pipes are local to the machine, same as the unix socket — no security model change.
- The kitty scrollback escape sequence in `handleMessage` is harmless on Windows terminals.